### PR TITLE
Spaces in path breaks wkhtmltopdf

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "moment" : "2.10.3",
     "z-schema": "3.10.2",
     "chalk": "1.0.0",
-    "spawn-args": "0.1.0",
     "cli-spinner": "0.2.1",
     "image-size": "0.3.5",
     "fs-extra": "0.18.4"

--- a/source/docgen.js
+++ b/source/docgen.js
@@ -8,7 +8,6 @@ var moment = require('moment');
 var childProcess = require("child_process");
 var schemaValidator = require("z-schema");
 var chalk = require('chalk');
-var spawnArgs = require('spawn-args');
 var cliSpinner = require('cli-spinner').Spinner;
 var imageSizeOf = require('image-size');
 
@@ -710,29 +709,39 @@ function DocGen (process)
     */
 
     var pdfOptions = [
-        ' --zoom 1.0',
-        ' --image-quality 100',
-        ' --print-media-type',
-        ' --orientation portrait',
-        ' --page-size A4',
-        ' --margin-top 25',
-        ' --margin-right 15',
-        ' --margin-bottom 16',
-        ' --margin-left 15',
-        ' --header-spacing 5',
-        ' --footer-spacing 5',
-        ' --no-stop-slow-scripts',
+        '--zoom', '1.0',
+        '--image-quality', '100',
+        '--print-media-type',
+        '--orientation', 'portrait',
+        '--page-size', 'A4',
+        '--margin-top', '25',
+        '--margin-right', '15',
+        '--margin-bottom', '16',
+        '--margin-left', '15',
+        '--header-spacing', '5',
+        '--footer-spacing', '5',
+        '--no-stop-slow-scripts',
     ];
 
     var getPdfArguments = function () {
         var pdfName = meta.parameters.name.toLowerCase()+'.pdf';
-        pdfOptions.push(' --javascript-delay '+options.pdfDelay);  //code syntax highlight in wkhtmltopdf 0.12.2.1 fails without a delay (but why doesn't --no-stop-slow-scripts work?)
-        pdfOptions.push(' --user-style-sheet '+__dirname+'/pdf-stylesheet.css');
-        pdfOptions.push(' --header-html '+options.output+'temp/pdfHeader.html');
-        pdfOptions.push(' --footer-html '+options.output+'temp/pdfFooter.html');
-        pdfOptions.push(' cover '+options.output+'temp/pdfCover.html');
-        pdfOptions.push(' toc --xsl-style-sheet '+__dirname+'/pdf-contents.xsl');
-        var allPages = '';
+        
+        // code syntax highlight in wkhtmltopdf 0.12.2.1 fails without a delay (but why doesn't --no-stop-slow-scripts work?)
+        pdfOptions.push('--javascript-delay');
+        pdfOptions.push(options.pdfDelay);
+        pdfOptions.push('--user-style-sheet');
+        pdfOptions.push(__dirname+'/pdf-stylesheet.css');
+        pdfOptions.push('--header-html');
+        pdfOptions.push(__dirname+'/templates/pdfHeader.html');
+        pdfOptions.push('--footer-html');
+        pdfOptions.push(__dirname+'/templates/pdfFooter.html');
+        pdfOptions.push('cover');
+        pdfOptions.push(__dirname+'/templates/pdfCover.html');
+        pdfOptions.push('toc');
+        pdfOptions.push('--xsl-style-sheet');
+        pdfOptions.push(__dirname+'/pdf-contents.xsl');
+        
+        // Add html files
         for (var key in sortedPages) {
             if (sortedPages.hasOwnProperty(key)) {
                 sortedPages[key].forEach( function (section) {
@@ -740,15 +749,16 @@ function DocGen (process)
                         var key = page.source;
                         var name = key.substr(0, page.source.lastIndexOf('.'));
                         var path = options.output+name+'.html';
-                        allPages += ' '+path;
+                        pdfOptions.push(path);
                     });
                 });
             }
         }
-        var args = pdfOptions.join('');
-        args += allPages;
-        args += ' '+options.output+pdfName;
-        return spawnArgs(args);
+        
+        // Add PDF file name
+        pdfOptions.push(options.output+pdfName);
+        
+        return pdfOptions;
     }
 
     var checkPdfVersion = function () {
@@ -787,6 +797,15 @@ function DocGen (process)
     var generatePdf = function () {
         console.log(chalk.green('Creating the PDF copy (may take some time)'));
         var args = getPdfArguments();
+
+        if (options.verbose === true) {
+            var cmdLine = '"' + options.wkhtmltopdfPath + '"';
+            for (var i = 0 ; i < args.length ; ++i) {
+                cmdLine += ' "' + args[i] + '"';
+            }
+            console.log(chalk.white("Command line: " + cmdLine));
+        }
+        
         var wkhtmltopdf = childProcess.spawn(options.wkhtmltopdfPath, args);
         var spinner = new cliSpinner(chalk.green('   Processing... %s'));
         spinner.setSpinnerString('|/-\\');

--- a/source/docgen.js
+++ b/source/docgen.js
@@ -3,7 +3,7 @@ var rsvp = require('rsvp');
 var fs = require('fs-extra');
 var path = require('path');
 var cheerio = require('cheerio');
-var markdown = require('markdown-it')('commonmark').enable('table');;
+var markdown = require('markdown-it')('commonmark').enable('table');
 var moment = require('moment');
 var childProcess = require("child_process");
 var schemaValidator = require("z-schema");
@@ -33,7 +33,7 @@ function DocGen (process)
 
     this.getVersion = function () {
         return version;
-    }
+    };
 
     this.setOptions = function (userOptions) {
         options = userOptions;
@@ -49,7 +49,7 @@ function DocGen (process)
         if (options.wkhtmltopdfPath && options.wkhtmltopdfPath !== '') {
             options.wkhtmltopdfPath = path.normalize(options.wkhtmltopdfPath);
         }
-    }
+    };
 
     /*
         copy the example source files (template) to any directory, when scaffold command is invoked
@@ -58,14 +58,14 @@ function DocGen (process)
     this.scaffold = function () {
         console.log(chalk.green('Creating scaffold template directory'));
         copyDirSync(__dirname+'/example', options.output);
-    }
+    };
 
     this.run = function () {
         console.log(chalk.green.bold('DocGen version '+version));
         //delete and recreate the output directory
         remakeDirSync(options.output);
         loadTemplates();
-    }
+    };
 
     /*
         read any file (async)
@@ -83,7 +83,7 @@ function DocGen (process)
                 }
             });
         });
-    }
+    };
 
     /*
         write any file (async)
@@ -100,7 +100,7 @@ function DocGen (process)
                 }
             });
         });
-    }
+    };
 
     /*
         copy any directory (sync)
@@ -116,7 +116,7 @@ function DocGen (process)
                 mainProcess.exit(1);
             }
         }
-    }
+    };
 
     /*
         remake a directory (sync) ... remove and then mkdir in one operation
@@ -133,7 +133,7 @@ function DocGen (process)
                 mainProcess.exit(1);
             }
         }
-    }
+    };
 
     /*
         remove any directory (sync)
@@ -149,7 +149,7 @@ function DocGen (process)
                 mainProcess.exit(1);
             }
         }
-    }
+    };
 
     /*
         load all HTML template files
@@ -181,7 +181,7 @@ function DocGen (process)
             }
             mainProcess.exit(1);
         });
-    }
+    };
 
     /*
         JSON schema validation
@@ -307,7 +307,7 @@ function DocGen (process)
             }
         }
         return valid;
-    }
+    };
 
     /*
         load all metadata files (JSON)
@@ -355,7 +355,7 @@ function DocGen (process)
             }
             mainProcess.exit(1);
         });
-    }
+    };
 
     /*
         load all markdown files (source)
@@ -400,7 +400,7 @@ function DocGen (process)
             }
             mainProcess.exit(1);
         });
-    }
+    };
 
     var sortPages = function () {
         //sort the contents by heading
@@ -412,7 +412,7 @@ function DocGen (process)
 
         });
         sortedPages = headings;
-    }
+    };
 
     /*
         build the HTML for the table of contents
@@ -458,7 +458,7 @@ function DocGen (process)
         html[++i] = '</tr></table></div>';
         $('#dg-toc').html(html.join(''));
         templates.main = $;
-    }
+    };
 
     /*
         insert the parameters into all templates
@@ -600,7 +600,7 @@ function DocGen (process)
                 //Note - wkhtmlpdf //cdn urls - see https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1634
             $('head').append('<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>');
         }
-    }
+    };
 
     /*
         process each input into an output
@@ -661,7 +661,7 @@ function DocGen (process)
         $('#dg-innerContent').html(templates.webCover.html());
         templates.webCover = $;
         writePages();
-    }
+    };
 
     /*
         write each html page
@@ -702,7 +702,7 @@ function DocGen (process)
             }
             mainProcess.exit(1);
         });
-    }
+    };
 
     /*
         wkthmltopdf options
@@ -759,7 +759,7 @@ function DocGen (process)
         pdfOptions.push(options.output+pdfName);
         
         return pdfOptions;
-    }
+    };
 
     var checkPdfVersion = function () {
         if (options.pdf === true) {
@@ -788,7 +788,7 @@ function DocGen (process)
         } else {
             cleanUp();
         }
-    }
+    };
 
     /*
         call wkhtmltopdf as an external executable
@@ -845,7 +845,7 @@ function DocGen (process)
             }
             cleanUp();
         });
-    }
+    };
 
     var createRedirect = function () {
         if (options.redirect) {
@@ -868,7 +868,7 @@ function DocGen (process)
                 //don't exit because redirect error is not a fatal error
             }
         }
-    }
+    };
 
     /*
         cleanup
@@ -881,7 +881,7 @@ function DocGen (process)
             removeDirSync(options.output+'temp');
         }
         console.log(chalk.green.bold('Done!'));
-    }
+    };
 }
 
 module.exports = DocGen;


### PR DESCRIPTION
This branch contains 2 commits. The first commit contains 2 fixes.

`source/docgen.js:getPdfArguments()`
When adding PDF option `header-html`, `footer-html` several of the files did not exist and so always wkhtmltopdf always threw an error. I modified them to point to template versions in the same way as `pdf-stylesheet`. Really, we/you should have a policy on overriding the default templates and add the options accordingly (rather than a load of errors, even if it is in debug).

The main reason for this commit was I noticed a problem when trying to use Docgen with Maven and Jenkins. After a lot of trouble and strange messages the problem boiled down to including spaces in the input and output options of the `docgen` command:
`docgen -v -i "/path/with/a/spa Ce/docgen" -o "/path/with/a/spa Ce/docgen-web" -p`
Node’s Commander returns the arguments correctly but when the are joined together as a string the parameter boundaries are lost. By the time it comes out of `spawnArgs` the correct arguments have been split into 2 separate arguments `/path/with/a/spa` and `Ce/docgen` and wkhtmltopdf fails with lots of messages like:

> Creating the PDF copy (may take some time)
> Loading pages (1/6)
> Error: Failed loading page http://Ce/docgen-web/docs/temp/pdfFooter.html (sometimes it will work just to ignore this error with --load-error-handling ignore)
> Error: Failed loading page http:///path/with/a/spa (sometimes it will work just to ignore this error with --load-error-handling ignore)
> Received createRequest signal on a disposed ResourceObject's NetworkAccessManager. This might be an indication of an iframe taking too long to load. ignore this error with --load-error handling ignore)
> Exit with code 1 due to network error: ProtocolUnknownError
> Warning: Received createRequest signal on a disposed ResourceObject's NetworkAccessManager. This might be an indication of an iframe taking too long to load.

The problem could have been solved by trying to wrap every file argument in quotes but it started to get messy so I decided it was simpler to modify the `pdfOptions` to be an array of arguments instead of an array of strings. As I was no longer using `spawn-args` I could remove the dependancy from `packages.json`.

The second commit just contains a bit of styling. Javascript declarations may or may not have a semi-colon at the end, but the style should choose and stick to it. I spent ages hunting for a missing ‘}’ because the javascript just reported that the error was on the last line. Adding the extra semi-colons forced the parser to error closer to the actual problem.

I think this fixes #13 as the new code adds `pdfName` into the argument's array as one item and so it no longer matters how many spaces are in it.
