### PR TITLE
Fix deprecated MathJax CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docgen-tool",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "description": "A tool for creating HTML and PDF documentation",
   "main": "dist/docgen.js",
   "bin": {

--- a/src/docgen/docgen.js
+++ b/src/docgen/docgen.js
@@ -703,8 +703,11 @@ function DocGen(process) {
       //support for MathJax (only supported via CDN due to very large size)
       //MathJax configuration is the same as used by math.stackexchange.com
       //Note - wkhtmlpdf //cdn urls - see https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1634
+      //Note - later than version 2 doesn't work with wkhtmltodpf
       $('head').append(
-        '<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>',
+        `<script type="text/javascript" id="MathJax-script" async
+          src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML">
+        </script>`,
       );
     }
   };

--- a/src/docs/parameters.json
+++ b/src/docs/parameters.json
@@ -1,8 +1,8 @@
 {
   "title": "DocGen - a documentation tool",
   "name": "DocGen",
-  "version": "3.2.11",
-  "date": "27/09/2023",
+  "version": "3.2.12",
+  "date": "28/09/2023",
   "organization": {
     "name": "Inkit Inc. and contributors",
     "url": "https://www.inkit.com"

--- a/src/docs/release-notes.md
+++ b/src/docs/release-notes.md
@@ -1,4 +1,8 @@
-﻿## DocGen 3.2.10 - 3.2.11 28/09/2023
+﻿## DocGen 3.2.12 28/09/2023
+
+- fix deprecated MathJax CDN ([#77](https://github.com/mtmacdonald/docgen/issues/77))
+
+## DocGen 3.2.10 - 3.2.11 28/09/2023
 
 - improve and modernise docs (website)
 

--- a/src/docs/writing-content.md
+++ b/src/docs/writing-content.md
@@ -46,7 +46,7 @@ Image files can be embedded (via links), and other files can be attached (the we
 
 Additionally, some website metadata is configured via [JSON](http://json.org) files.
 
-# Overview
+## Overview
 
 DocGen transforms source files from an input directory into output files in an output directory.
 
@@ -58,7 +58,7 @@ directory to the output.
 
 > Always save input files with **UTF-8** encoding. This makes non-standard characters (ø © é etc.) work.
 
-# Metadata
+## Metadata
 
 **parameters.json**
 
@@ -94,7 +94,7 @@ the web and PDF table of contents.
 The release notes source file is a mandatory source file (that does not need to be listed in contents.json). Use it to
 summarize the change history for each version of the product.
 
-# Plain text
+## Plain text
 
 The simplest input format is just to write in plain text. Here is an example of the source and output:
 
@@ -111,7 +111,7 @@ Example paragraph.
 
 <p class="dg-forceBreak"></p>
 
-# Markdown
+## Markdown
 
 [Markdown](https://www.markdownguide.org/) is a human-friendly plain text markup format. The source format is easy
 to read and write, and the CommonMark parser translates it into HTML. DocGen uses the [CommonMark](http://commonmark.org/)
@@ -149,7 +149,7 @@ Here is an [example link](http://www.google.com).
 
 For more examples, see the [CommonMark reference](commonmark.html).
 
-# HTML
+## HTML
 
 For more complex pages not covered by CommonMark's syntax, simply use inline HTML:
 
@@ -178,7 +178,7 @@ For more examples, see [writing advanced content](advanced-content.html).
 possible to bypass the CommonMark parser altogether and specify a pure HTML input page, by setting 
 <code class="w-inline-code">"html": true</code> in a page object in *contents.json*.
 
-# Embedding images
+## Embedding images
 
 Diagrams (in image form, e.g. JPEG, PNG, GIF etc.) should be put the *files/images* directory, and embedded as image
 links.
@@ -190,7 +190,7 @@ links.
 <img src="files/images/logo.svg" />
 </div><br class="w-clear"/>
 
-# Attaching files
+## Attaching files
 
 Other files you want to attach should go into *files* directory.
 
@@ -201,7 +201,7 @@ Other files you want to attach should go into *files* directory.
 <a href="user_guide.pdf">attachment</a>
 </div><br class="w-clear"/>
 
-# Mathematical Expressions
+## Mathematical Expressions
 
 [LaTeX](http://en.wikipedia.org/wiki/LaTeX) is the most common markup format for mathematical expressions.
 
@@ -215,7 +215,7 @@ The document author decides which one (or both) to use.
 
 <p class="dg-forceBreak"></p>
 
-## Mathematics using KaTeX
+### Mathematics using KaTeX
 
 KaTeX is the recommended choice. It is bundled with DocGen but must be enabled by passing the 
 **-m** option.
@@ -235,7 +235,7 @@ f(x) = \int_{-\infty}^\infty
 </div>
 </div><br class="w-clear"/>
 
-## Mathematics using MathJax
+### Mathematics using MathJax
 
 MathJax is the fallback choice for expressions not yet supported by KaTex. When required, MathJax can be enabled by 
 passing the **-n** option.


### PR DESCRIPTION
Closes #77. Fix deprecated MathJax CDN.