### PR TITLE
Add Github pre-merge checks (CI/CD)

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -25,7 +25,7 @@ jobs:
         run: yarn prettier:check
 
       - name: Check Types
-        run: yarn lint:check
+        run: yarn check:types
 
       - name: Build icons
         run: yarn build:icons

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Check Formatting
         run: yarn prettier:check
 
-      - name: Check Types
-        run: yarn check:types
+      # - name: Check Types
+      #   run: yarn check:types
 
       - name: Build icons
         run: yarn build:icons

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,0 +1,49 @@
+name: Pre-Merge Checks
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Check Formatting
+        run: yarn prettier:check
+
+      - name: Check Types
+        run: yarn lint:check
+
+      - name: Build icons
+        run: yarn build:icons
+
+      - name: Build styles
+        run: yarn build:styles
+
+      - name: Build package
+        run: yarn build
+
+      - name: Run DocGen scaffold (DEV)
+        run: yarn test:scaffold
+
+      - name: Run DocGen (DEV)
+        run: yarn test:run
+
+      - name: Run DocGen (PROD)
+        run: yarn test:run:prod
+
+      - name: Test Publish (Dry-Run)
+        run: yarn test:publish

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn test:run
 
       - name: Run DocGen (PROD)
-        run: yarn test:run:prod
+        run: yarn test:prod:run
 
       - name: Test Publish (Dry-Run)
         run: yarn test:publish


### PR DESCRIPTION
Closes #120. We need automated CI checks on QA commands before merge.

Here's how it looks. We're just invoking some NPM commands for QA before merge. TypeScript checks will be in next increment.

<img width="945" height="313" alt="Screenshot 2025-07-23 at 16 29 16" src="https://github.com/user-attachments/assets/0ae565d1-1d82-4520-88f3-cac38e7c0a7d" />

<img width="1716" height="827" alt="Screenshot 2025-07-23 at 16 29 27" src="https://github.com/user-attachments/assets/f7c7f299-b9b4-44a3-8ceb-440379aab30b" />
