### PR TITLE
Pre-merge checks: check types

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Check Formatting
         run: yarn prettier:check
 
-      # - name: Check Types
-      #   run: yarn check:types
+      - name: Check Types
+        run: yarn check:types
 
       - name: Build icons
         run: yarn build:icons

--- a/src/docgen/pdf/react-pdf/react-pdf.tsx
+++ b/src/docgen/pdf/react-pdf/react-pdf.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Document } from '@react-pdf/renderer';
 import { PdfPage } from './pdf-page/pdf-page.tsx';
 
@@ -22,12 +22,13 @@ export const Pdf = ({
   return (
     <Document>
       {Object.values(pages).map((page, i) => (
-        <PdfPage
-          key={i}
-          page={page}
-          parameters={parameters}
-          options={options}
-        />
+        <Fragment key={i}>
+          <PdfPage
+            page={page}
+            parameters={parameters}
+            options={options}
+          />
+        </Fragment>
       ))}
     </Document>
   );

--- a/src/docgen/views/components/page/page.tsx
+++ b/src/docgen/views/components/page/page.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
-export const Page = ({children}) => {
+type PageProps = {
+  children?: ReactNode;
+};
+
+export const Page = ({children} : PageProps) => {
   return (
     <div
       className="page"


### PR DESCRIPTION
This finishes off #120:

- Fixes `yarn check:types` so it passes on Linux (two stricter rules were failing)
- Adds the command to the pre-merge checks